### PR TITLE
fix: fixes embedding properties selection

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -1230,12 +1230,12 @@ pub struct InsertDocumentsResult {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
 pub enum IndexEmbeddingsCalculation {
     #[serde(rename = "automatic")]
     Automatic,
     #[serde(rename = "all_properties")]
     AllProperties,
-    #[serde(rename = "properties")]
     Properties(Vec<String>),
     #[serde(rename = "hook")]
     Hook,
@@ -1260,6 +1260,7 @@ pub struct ReplaceIndexRequest {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct InsertToolsParams {
     pub id: String,
+    pub system_prompt: Option<String>,
     pub description: String,
     pub parameters: String,
     pub code: Option<String>,
@@ -1273,6 +1274,7 @@ pub struct DeleteToolParams {
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct UpdateToolParams {
     pub id: String,
+    pub system_prompt: Option<String>,
     pub name: String,
     pub description: String,
     pub parameters: String,


### PR DESCRIPTION
This pull request introduces significant changes to improve the handling of embedding field calculations, enhance data model flexibility, and add new optional fields to tool-related structs. The most important changes include replacing a recursive function with an iterative one to address a capacity overflow issue, updating the `IndexEmbeddingsCalculation` enum for better serialization, and adding a `system_prompt` field to several structs.

### Improvements to embedding field calculations:
* Replaced the recursive `recursive_object_inspection` function with a non-recursive `extract_values_at_paths` function to prevent capacity overflow errors during embedding string calculations. The new function includes a maximum result size limit (10MB) and handles nested fields and arrays more robustly.

### Enhancements to data model flexibility:
* Updated the `IndexEmbeddingsCalculation` enum to use `#[serde(untagged)]` for better serialization and deserialization, and removed the explicit `#[serde(rename = "properties")]` attribute for the `Properties` variant.

### Additions to tool-related structs:
* Added an optional `system_prompt` field to the `InsertToolsParams` and `UpdateToolParams` structs to support additional configuration options for tools. [[1]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0R1263) [[2]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0R1277)