### PR TITLE
feat: adds support for Google Vertex APIs

### DIFF
--- a/src/ai/llms.rs
+++ b/src/ai/llms.rs
@@ -385,6 +385,35 @@ impl LLMService {
                             ),
                         );
                     }
+                    RemoteLLMProvider::GoogleVertex => {
+                        info!("Found Google Vertex remote LLM provider");
+
+                        match conf.default_model.as_str() {
+                            "" => {
+                                return Err(anyhow::Error::msg(
+                                    "Default model is required for Google Vertex provider",
+                                ));
+                            }
+                            _ => {
+                                default_remote_models.insert(
+                                    RemoteLLMProvider::GoogleVertex,
+                                    conf.default_model.clone(),
+                                );
+                            }
+                        }
+
+                        remote_llm_providers.insert(
+                            RemoteLLMProvider::GoogleVertex,
+                            async_openai::Client::with_config(
+                                OpenAIConfig::new()
+                                    .with_api_key(&conf.api_key)
+                                    .with_api_base(conf.url.unwrap_or_else(|| {
+                                        "https://generativelanguage.googleapis.com/v1beta/openai"
+                                            .to_string()
+                                    })),
+                            ),
+                        );
+                    }
                     #[allow(unreachable_patterns)]
                     _ => {
                         return Err(anyhow::Error::msg(format!(

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -57,6 +57,7 @@ pub enum RemoteLLMProvider {
     OpenAI,
     Fireworks,
     Together,
+    GoogleVertex,
 }
 
 impl FromStr for RemoteLLMProvider {
@@ -65,6 +66,10 @@ impl FromStr for RemoteLLMProvider {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "openai" => Ok(RemoteLLMProvider::OpenAI),
+            "google" => Ok(RemoteLLMProvider::GoogleVertex),
+            "google_vertex" => Ok(RemoteLLMProvider::GoogleVertex),
+            "googlevertex" => Ok(RemoteLLMProvider::GoogleVertex),
+            "vertex" => Ok(RemoteLLMProvider::GoogleVertex),
             _ => Err(anyhow!("Invalid remote LLM provider: {}", s)),
         }
     }


### PR DESCRIPTION
This pull request introduces support for the Google Vertex AI as a new remote LLM provider. The changes include adding the provider to the enum, updating the configuration logic, and extending the string parsing functionality to recognize multiple aliases for Google Vertex.

### Support for Google Vertex AI:

* [`src/ai/mod.rs`](diffhunk://#diff-c92933fff6042763478495d0560c4c77564fb486c27fecae8a1d5be1021206bbR60): Added `GoogleVertex` as a new variant to the `RemoteLLMProvider` enum.
* [`src/ai/mod.rs`](diffhunk://#diff-c92933fff6042763478495d0560c4c77564fb486c27fecae8a1d5be1021206bbR69-R72): Updated the `FromStr` implementation for `RemoteLLMProvider` to recognize multiple aliases for Google Vertex, including "google", "google_vertex", "googlevertex", and "vertex".
* [`src/ai/llms.rs`](diffhunk://#diff-7bded09a70e5daca5552f41f398574cfd12938d75d74775859547d894e65968aR388-R416): Added logic to configure and initialize the Google Vertex provider, including handling the default model requirement and API key setup.