### PR TITLE
Implement date type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1412,6 +1412,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
+name = "dateparser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ef451feee09ae5ecd8a02e738bd9adee9266b8fa9b44e22d3ce968d8694238"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "debug_panic"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,6 +4174,7 @@ dependencies = [
  "csv",
  "cuid2",
  "dashmap",
+ "dateparser",
  "debug_panic",
  "dedent",
  "dircpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ filters = { path = "./crates/filters" }
 
 zebo = "0.1.2"
 llm_json = "1.0.2"
+dateparser = "0.2.1"
 
 [build-dependencies]
 cc = "1"

--- a/src/collection_manager/sides/operation/op.rs
+++ b/src/collection_manager/sides/operation/op.rs
@@ -119,6 +119,7 @@ pub enum IndexWriteOperationFieldType {
     Number,
     Bool,
     StringFilter,
+    Date,
     String,
     Embedding(OramaModelSerializable),
 }

--- a/src/collection_manager/sides/read/collection.rs
+++ b/src/collection_manager/sides/read/collection.rs
@@ -21,7 +21,10 @@ use crate::{
         llms::LLMService,
         AIService,
     },
-    collection_manager::sides::{CollectionWriteOperation, Offset, ReplaceIndexReason},
+    collection_manager::sides::{
+        CollectionWriteOperation, CommittedDateFieldStats, Offset, ReplaceIndexReason,
+        UncommittedDateFieldStats,
+    },
     file_utils::BufferedFile,
     nlp::{locales::Locale, NLPService},
     types::{
@@ -625,6 +628,11 @@ pub enum IndexFieldStatsType {
     UncommittedNumber(UncommittedNumberFieldStats),
     #[serde(rename = "committed_number")]
     CommittedNumber(CommittedNumberFieldStats),
+
+    #[serde(rename = "uncommitted_date")]
+    UncommittedDate(UncommittedDateFieldStats),
+    #[serde(rename = "committed_date")]
+    CommittedDate(CommittedDateFieldStats),
 
     #[serde(rename = "uncommitted_string_filter")]
     UncommittedStringFilter(UncommittedStringFilterFieldStats),

--- a/src/collection_manager/sides/read/index/committed_field.rs
+++ b/src/collection_manager/sides/read/index/committed_field.rs
@@ -1,4 +1,5 @@
 pub use bool::{BoolFieldInfo, BoolWrapper, CommittedBoolField, CommittedBoolFieldStats};
+pub use date::{CommittedDateField, CommittedDateFieldStats, DateFieldInfo};
 pub use number::{CommittedNumberField, CommittedNumberFieldStats, NumberFieldInfo};
 pub use string::{CommittedStringField, CommittedStringFieldStats, StringFieldInfo};
 pub use string_filter::{
@@ -7,6 +8,7 @@ pub use string_filter::{
 pub use vector::{CommittedVectorField, CommittedVectorFieldStats, VectorFieldInfo};
 
 mod bool;
+mod date;
 mod number;
 mod string;
 mod string_filter;

--- a/src/collection_manager/sides/read/index/committed_field/date.rs
+++ b/src/collection_manager/sides/read/index/committed_field/date.rs
@@ -1,0 +1,119 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    indexes::ordered_key::{BoundedValue, OrderedKeyIndex},
+    types::{DateFilter, DocumentId, OramaDate},
+};
+
+#[derive(Debug)]
+pub struct CommittedDateField {
+    field_path: Box<[String]>,
+    inner: OrderedKeyIndex<i64, DocumentId>,
+    data_dir: PathBuf,
+}
+
+impl CommittedDateField {
+    pub fn from_iter<I>(field_path: Box<[String]>, iter: I, data_dir: PathBuf) -> Result<Self>
+    where
+        I: Iterator<Item = (i64, HashSet<DocumentId>)>,
+    {
+        let inner = OrderedKeyIndex::from_iter(iter, data_dir.clone())?;
+        Ok(Self {
+            field_path,
+            inner,
+            data_dir,
+        })
+    }
+
+    pub fn try_load(info: DateFieldInfo) -> Result<Self> {
+        let data_dir = info.data_dir;
+        let inner = OrderedKeyIndex::load(data_dir.clone())?;
+        Ok(Self {
+            inner,
+            field_path: info.field_path,
+            data_dir,
+        })
+    }
+
+    pub fn get_field_info(&self) -> DateFieldInfo {
+        DateFieldInfo {
+            field_path: self.field_path.clone(),
+            data_dir: self.data_dir.clone(),
+        }
+    }
+
+    pub fn field_path(&self) -> &[String] {
+        &self.field_path
+    }
+
+    pub fn stats(&self) -> Result<CommittedDateFieldStats> {
+        let s = self
+            .inner
+            .min_max()
+            .context("Cannot get min and max key for date index")?;
+        let Some((min, max)) = s else {
+            return Ok(CommittedDateFieldStats {
+                min: None,
+                max: None,
+            });
+        };
+
+        let min = OramaDate::try_from_i64(min);
+        let max = OramaDate::try_from_i64(max);
+
+        Ok(CommittedDateFieldStats { min, max })
+    }
+
+    pub fn filter<'s, 'iter>(
+        &'s self,
+        filter_date: &DateFilter,
+    ) -> Result<impl Iterator<Item = DocumentId> + 'iter>
+    where
+        's: 'iter,
+    {
+        let (min, max) = match filter_date {
+            DateFilter::Equal(value) => ((true, value.as_i64()), (true, value.as_i64())),
+            DateFilter::Between((min, max)) => ((true, min.as_i64()), (true, max.as_i64())),
+            DateFilter::GreaterThan(min) => ((false, min.as_i64()), (true, i64::MAX)),
+            DateFilter::GreaterThanOrEqual(min) => ((true, min.as_i64()), (true, i64::MAX)),
+            DateFilter::LessThan(max) => ((true, i64::MIN), (false, max.as_i64())),
+            DateFilter::LessThanOrEqual(max) => ((true, i64::MIN), (true, max.as_i64())),
+        };
+
+        let items = self
+            .inner
+            .get_items(min, max)
+            .context("Cannot get items for date index")?;
+
+        Ok(items.flat_map(|item| item.values))
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (i64, HashSet<DocumentId>)> + '_ {
+        self.inner.iter()
+    }
+}
+
+impl BoundedValue for i64 {
+    fn max_value() -> Self {
+        i64::MAX
+    }
+
+    fn min_value() -> Self {
+        i64::MIN
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DateFieldInfo {
+    pub field_path: Box<[String]>,
+    pub data_dir: PathBuf,
+}
+
+#[derive(Serialize, Debug)]
+pub struct CommittedDateFieldStats {
+    pub min: Option<OramaDate>,
+    pub max: Option<OramaDate>,
+}

--- a/src/collection_manager/sides/read/index/path_to_index_id_map.rs
+++ b/src/collection_manager/sides/read/index/path_to_index_id_map.rs
@@ -4,6 +4,7 @@ use crate::{collection_manager::sides::field_name_to_path, types::FieldId};
 
 use super::FieldType;
 
+#[derive(Debug)]
 pub struct PathToIndexId {
     filter_fields: HashMap<Box<[String]>, (FieldId, FieldType)>,
     score_fields: HashMap<Box<[String]>, (FieldId, FieldType)>,

--- a/src/collection_manager/sides/read/index/uncommitted_field.rs
+++ b/src/collection_manager/sides/read/index/uncommitted_field.rs
@@ -1,10 +1,12 @@
 pub use bool::{UncommittedBoolField, UncommittedBoolFieldStats};
+pub use date::{UncommittedDateFieldStats, UncommittedDateFilterField};
 pub use number::{UncommittedNumberField, UncommittedNumberFieldStats};
 pub use string::{UncommittedStringField, UncommittedStringFieldStats};
 pub use string_filter::{UncommittedStringFilterField, UncommittedStringFilterFieldStats};
 pub use vector::{UncommittedVectorField, UncommittedVectorFieldStats};
 
 mod bool;
+mod date;
 mod number;
 mod string;
 mod string_filter;

--- a/src/collection_manager/sides/read/index/uncommitted_field/date.rs
+++ b/src/collection_manager/sides/read/index/uncommitted_field/date.rs
@@ -1,0 +1,134 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    ops::Bound,
+};
+
+use serde::Serialize;
+
+use crate::types::{DateFilter, DocumentId, OramaDate};
+
+#[derive(Debug)]
+pub struct UncommittedDateFilterField {
+    field_path: Box<[String]>,
+    inner: BTreeMap<i64, HashSet<DocumentId>>,
+}
+
+impl UncommittedDateFilterField {
+    pub fn empty(field_path: Box<[String]>) -> Self {
+        Self {
+            field_path,
+            inner: BTreeMap::new(),
+        }
+    }
+
+    pub fn field_path(&self) -> &[String] {
+        &self.field_path
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn clear(&mut self) {
+        self.inner = Default::default();
+    }
+
+    pub fn insert(&mut self, doc_id: DocumentId, value: i64) {
+        self.inner.entry(value).or_default().insert(doc_id);
+    }
+
+    pub fn filter<'s, 'iter>(
+        &'s self,
+        filter_date: &DateFilter,
+    ) -> impl Iterator<Item = DocumentId> + 'iter
+    where
+        's: 'iter,
+    {
+        inner_filter(&self.inner, filter_date)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (i64, HashSet<DocumentId>)> + '_ {
+        self.inner
+            .iter()
+            .map(|(number, doc_ids)| (*number, doc_ids.clone()))
+    }
+
+    pub fn stats(&self) -> UncommittedDateFieldStats {
+        if self.inner.is_empty() {
+            return UncommittedDateFieldStats {
+                min: None,
+                max: None,
+                count: 0,
+            };
+        }
+
+        let (Some((min, _)), Some((max, _))) =
+            (self.inner.first_key_value(), self.inner.last_key_value())
+        else {
+            return UncommittedDateFieldStats {
+                min: None,
+                max: None,
+                count: 0,
+            };
+        };
+
+        let min = OramaDate::try_from_i64(*min);
+        let max = OramaDate::try_from_i64(*max);
+
+        UncommittedDateFieldStats {
+            min,
+            max,
+            count: self.len(),
+        }
+    }
+}
+
+#[inline]
+fn inner_filter<'tree, 'iter>(
+    tree: &'tree BTreeMap<i64, HashSet<DocumentId>>,
+    filter: &DateFilter,
+) -> impl Iterator<Item = DocumentId> + 'iter
+where
+    'tree: 'iter,
+{
+    fn flat_doc<'tree>(
+        (_, doc_ids): (&'tree i64, &'tree HashSet<DocumentId>),
+    ) -> impl Iterator<Item = DocumentId> + 'tree {
+        doc_ids.iter().copied()
+    }
+
+    match filter {
+        DateFilter::Equal(value) => tree
+            .range((
+                Bound::Included(value.as_i64()),
+                Bound::Included(value.as_i64()),
+            ))
+            .flat_map(flat_doc),
+        DateFilter::LessThan(value) => tree
+            .range((Bound::Unbounded, Bound::Excluded(value.as_i64())))
+            .flat_map(flat_doc),
+        DateFilter::LessThanOrEqual(value) => tree
+            .range((Bound::Unbounded, Bound::Included(value.as_i64())))
+            .flat_map(flat_doc),
+        DateFilter::GreaterThan(value) => tree
+            .range((Bound::Excluded(value.as_i64()), Bound::Unbounded))
+            .flat_map(flat_doc),
+        DateFilter::GreaterThanOrEqual(value) => tree
+            .range((Bound::Included(value.as_i64()), Bound::Unbounded))
+            .flat_map(flat_doc),
+        DateFilter::Between((min, max)) => tree
+            .range((Bound::Included(min.as_i64()), Bound::Included(max.as_i64())))
+            .flat_map(flat_doc),
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct UncommittedDateFieldStats {
+    pub min: Option<OramaDate>,
+    pub max: Option<OramaDate>,
+    pub count: usize,
+}

--- a/src/collection_manager/sides/write/index/mod.rs
+++ b/src/collection_manager/sides/write/index/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     nlp::{locales::Locale, TextParser},
     types::{
         CollectionId, DescribeCollectionIndexResponse, Document, DocumentId, DocumentList, FieldId,
-        IndexEmbeddingsCalculation, IndexFieldType, IndexId,
+        IndexEmbeddingsCalculation, IndexFieldType, IndexId, OramaDate,
     },
 };
 
@@ -637,6 +637,7 @@ impl Index {
                                 IndexFilterField::String(_) => {
                                     IndexWriteOperationFieldType::StringFilter
                                 }
+                                IndexFilterField::Date(_) => IndexWriteOperationFieldType::Date,
                             },
                         },
                     ),
@@ -720,9 +721,14 @@ fn calculate_fields_for(
             let field = IndexFilterField::new_number(generate_id(), field_path);
             filter_field = Some(field);
         }
-        Value::String(_) => {
-            let field = IndexFilterField::new_string(generate_id(), field_path.clone());
-            filter_field = Some(field);
+        Value::String(s) => {
+            if OramaDate::try_from(s).is_ok() {
+                let field = IndexFilterField::new_date(generate_id(), field_path.clone());
+                filter_field = Some(field);
+            } else {
+                let field = IndexFilterField::new_string(generate_id(), field_path.clone());
+                filter_field = Some(field);
+            }
 
             let field = IndexScoreField::new_string(generate_id(), field_path, text_parser.clone());
             score_field = Some(field);

--- a/src/tests/filter.rs
+++ b/src/tests/filter.rs
@@ -1,6 +1,9 @@
 use serde_json::json;
 
-use crate::tests::utils::{init_log, TestContext};
+use crate::{
+    tests::utils::{init_log, TestContext},
+    types::SearchParams,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_search_on_unknown_field() {
@@ -450,6 +453,249 @@ async fn test_filter_and_or_not() {
         .await
         .unwrap();
     assert_eq!(output.count, 50);
+
+    drop(test_context);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_date() {
+    init_log();
+
+    let test_context = TestContext::new().await;
+    let collection_client = test_context.create_collection().await.unwrap();
+    let index_client = collection_client.create_index().await.unwrap();
+
+    let result = index_client
+        .insert_documents(
+            json!([
+                {
+                    "id": "1",
+                    "text": "test",
+                    "date": "2023-01-01T00:00:00Z"
+                },
+                {
+                    "id": "2",
+                    "text": "test",
+                    "date": "2023-01-02T00:00:00Z"
+                },
+                {
+                    "id": "3",
+                    "text": "test",
+                    "date": "2023-01-03T00:00:00Z"
+                }
+            ])
+            .try_into()
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(result.inserted, 3);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "gt": "2023-01-01T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 2);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "lt": "2023-01-03T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 2);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "gte": "2023-01-01T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 3);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "lte": "2023-01-03T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 3);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "between": ["2023-01-01T00:00:01Z", "2023-01-02T23:59:59Z"]
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 1);
+
+    test_context.commit_all().await.unwrap();
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "gt": "2023-01-01T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 2);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "lt": "2023-01-03T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 2);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "gte": "2023-01-01T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 3);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "lte": "2023-01-03T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 3);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "between": ["2023-01-01T00:00:01Z", "2023-01-02T23:59:59Z"]
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 1);
+
+    let test_context = test_context.reload().await;
+    let collection_client = test_context
+        .get_test_collection_client(
+            collection_client.collection_id,
+            collection_client.write_api_key,
+            collection_client.read_api_key,
+        )
+        .unwrap();
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "gt": "2023-01-01T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 2);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "lt": "2023-01-03T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 2);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "gte": "2023-01-01T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 3);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "lte": "2023-01-03T00:00:00Z"
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 3);
+
+    let search_params: SearchParams = json!({
+        "term": "",
+        "where": {
+            "date": {
+                "between": ["2023-01-01T00:00:01Z", "2023-01-02T23:59:59Z"]
+            }
+        }
+    })
+    .try_into()
+    .unwrap();
+    let output = collection_client.search(search_params).await.unwrap();
+    assert_eq!(output.count, 1);
 
     drop(test_context);
 }


### PR DESCRIPTION
This pull request introduces support for date fields in the indexing system. It adds functionality for handling committed and uncommitted date fields, including operations like merging, filtering, and retrieving statistics. The changes span multiple files and focus on integrating date field support into the existing framework.

### Support for Date Fields in Indexing

**Core Changes:**
- **Added `Date` field type:** The `IndexWriteOperationFieldType` enum now includes a `Date` variant to represent date fields. (`src/collection_manager/sides/operation/op.rs`)
- **Introduced committed and uncommitted date field stats:** Added `CommittedDateFieldStats` and `UncommittedDateFieldStats` to the `IndexFieldStatsType` enum for tracking statistics of date fields. (`src/collection_manager/sides/read/collection.rs`)
- **Implemented `CommittedDateField` class:** This class manages committed date fields, including methods for loading, filtering, iterating, and retrieving statistics. (`src/collection_manager/sides/read/index/committed_field/date.rs`)

**Integration into Indexing Workflow:**
- **Enhanced `Index` struct:** Added support for `date_fields` in both committed and uncommitted fields. (`src/collection_manager/sides/read/index/mod.rs`) [[1]](diffhunk://#diff-f539349485974f04ff20b3d4df0f9d47c1ff2a5579137d33bc979ca54bb7ed81R92) [[2]](diffhunk://#diff-f539349485974f04ff20b3d4df0f9d47c1ff2a5579137d33bc979ca54bb7ed81R102)
- **Integrated merging logic for date fields:** Implemented `merge_date_field` function to handle merging of uncommitted and committed date fields during indexing operations. (`src/collection_manager/sides/read/index/merge.rs`)
- **Updated indexing operations:** Modified the `Index` implementation to include date fields in operations like field insertion, merging, and statistics generation. (`src/collection_manager/sides/read/index/mod.rs`) [[1]](diffhunk://#diff-f539349485974f04ff20b3d4df0f9d47c1ff2a5579137d33bc979ca54bb7ed81R213-R222) [[2]](diffhunk://#diff-f539349485974f04ff20b3d4df0f9d47c1ff2a5579137d33bc979ca54bb7ed81R393-R418) [[3]](diffhunk://#diff-f539349485974f04ff20b3d4df0f9d47c1ff2a5579137d33bc979ca54bb7ed81R1000-R1007)

### Dependency Update

- **Added `dateparser` dependency:** Included the `dateparser` crate in `Cargo.toml` to support date-related functionality. (`Cargo.toml`)