### PR TITLE
Feat: allow custom RAG options and reset some defaults

### DIFF
--- a/src/ai/answer.rs
+++ b/src/ai/answer.rs
@@ -220,7 +220,6 @@ impl Answer {
 
         let mut search_results = Vec::<SearchResultHit>::new();
         if let Some(ref notation) = interaction.ragat_notation {
-            print!("Parsing notation: {}", notation);
             let parsed = RAGAtParser::parse(&notation);
 
             let components = self

--- a/src/ai/answer.rs
+++ b/src/ai/answer.rs
@@ -239,7 +239,7 @@ impl Answer {
             let search_mode = match interaction
                 .search_mode
                 .as_ref()
-                .map_or("fulltext", |s| s.as_str())
+                .map_or("vector", |s| s.as_str())
             {
                 "vector" => SearchMode::Vector(VectorMode {
                     term: interaction.query.clone(),

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -26,6 +26,7 @@ pub mod context_evaluator;
 pub mod gpu;
 pub mod llms;
 pub mod party_planner;
+pub mod ragat;
 pub mod tools;
 
 tonic::include_proto!("orama_ai_service");

--- a/src/ai/ragat.rs
+++ b/src/ai/ragat.rs
@@ -1,0 +1,215 @@
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContextComponent {
+    pub source_ids: Vec<String>,
+    pub threshold: f32,
+    pub max_documents: usize,
+    pub fill_remaining: bool,
+    pub is_exclusion: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParseResult {
+    pub components: Vec<ContextComponent>,
+    pub success: bool,
+    pub error_message: Option<String>,
+    pub error_position: Option<usize>,
+}
+
+#[derive(Debug)]
+pub enum ParseError {
+    InvalidSyntax(String),
+    InvalidThreshold(String),
+    InvalidMaxDocuments(String),
+    EmptySourceList,
+    MissingAtSymbol,
+    MissingColon,
+    UnexpectedCharacter(char, usize),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::InvalidSyntax(msg) => write!(f, "Invalid syntax: {}", msg),
+            ParseError::InvalidThreshold(val) => write!(f, "Invalid threshold value: {}", val),
+            ParseError::InvalidMaxDocuments(val) => write!(f, "Invalid max documents: {}", val),
+            ParseError::EmptySourceList => write!(f, "Source list cannot be empty"),
+            ParseError::MissingAtSymbol => write!(f, "Missing @ symbol for threshold"),
+            ParseError::MissingColon => write!(f, "Missing : symbol for max documents"),
+            ParseError::UnexpectedCharacter(ch, pos) => {
+                write!(f, "Unexpected character '{}' at position {}", ch, pos)
+            }
+        }
+    }
+}
+
+pub struct RAGAtParser;
+
+impl RAGAtParser {
+    /// Parse RAG@ notation string into ContextComponents
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rag_at::RAGAtParser;
+    ///
+    /// let notation = "[idx1,idx2]@0.7:6; ![idx3,idx4]@0.85:4+";
+    /// let result = RAGAtParser::parse(notation);
+    pub fn parse(notation: &str) -> ParseResult {
+        match Self::parse_internal(notation) {
+            Ok(components) => ParseResult {
+                components,
+                success: true,
+                error_message: None,
+                error_position: None,
+            },
+            Err(error) => ParseResult {
+                components: Vec::new(),
+                success: false,
+                error_message: Some(error.to_string()),
+                error_position: None, // Could be enhanced to track positions
+            },
+        }
+    }
+
+    fn parse_internal(notation: &str) -> Result<Vec<ContextComponent>, ParseError> {
+        let notation = notation.trim();
+        if notation.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let component_strings: Vec<&str> = notation.split(';').collect();
+        let mut components = Vec::new();
+
+        for component_str in component_strings {
+            let component = Self::parse_component(component_str.trim())?;
+            components.push(component);
+        }
+
+        Ok(components)
+    }
+
+    fn parse_component(component_str: &str) -> Result<ContextComponent, ParseError> {
+        if component_str.is_empty() {
+            return Err(ParseError::InvalidSyntax("Empty component".to_string()));
+        }
+
+        let (is_exclusion, remaining) = if component_str.starts_with('!') {
+            (true, &component_str[1..])
+        } else {
+            (false, component_str)
+        };
+
+        let at_pos = remaining.find('@').ok_or(ParseError::MissingAtSymbol)?;
+
+        let source_part = &remaining[..at_pos].trim();
+        let params_part = &remaining[at_pos + 1..];
+
+        let source_ids = Self::parse_source_ids(source_part)?;
+
+        let (threshold, max_documents, fill_remaining) = Self::parse_params(params_part)?;
+
+        Ok(ContextComponent {
+            source_ids,
+            threshold,
+            max_documents,
+            fill_remaining,
+            is_exclusion,
+        })
+    }
+
+    fn parse_source_ids(source_part: &str) -> Result<Vec<String>, ParseError> {
+        let source_part = source_part.trim();
+
+        if source_part.is_empty() {
+            return Err(ParseError::EmptySourceList);
+        }
+
+        let inner = source_part;
+        if inner.is_empty() {
+            return Err(ParseError::EmptySourceList);
+        }
+
+        let ids: Vec<String> = inner
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if ids.is_empty() {
+            return Err(ParseError::EmptySourceList);
+        }
+
+        Ok(ids)
+    }
+
+    fn parse_params(params_part: &str) -> Result<(f32, usize, bool), ParseError> {
+        let colon_pos = params_part.find(':').ok_or(ParseError::MissingColon)?;
+
+        let threshold_str = &params_part[..colon_pos];
+        let max_docs_str = &params_part[colon_pos + 1..];
+
+        let threshold = threshold_str
+            .trim()
+            .parse::<f32>()
+            .map_err(|_| ParseError::InvalidThreshold(threshold_str.to_string()))?;
+
+        let (max_docs_str, fill_remaining) = if max_docs_str.ends_with('+') {
+            (&max_docs_str[..max_docs_str.len() - 1], true)
+        } else {
+            (max_docs_str, false)
+        };
+
+        let max_documents = max_docs_str
+            .trim()
+            .parse::<usize>()
+            .map_err(|_| ParseError::InvalidMaxDocuments(max_docs_str.to_string()))?;
+
+        Ok((threshold, max_documents, fill_remaining))
+    }
+
+    pub fn validate_sources(
+        components: &[ContextComponent],
+        available_indexes: &HashSet<String>,
+    ) -> Result<(), String> {
+        for (i, component) in components.iter().enumerate() {
+            for source_id in &component.source_ids {
+                if !available_indexes.contains(source_id) {
+                    return Err(format!(
+                        "Component {}: Source ID '{}' not found in available indexes",
+                        i, source_id
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn extract_all_source_ids(components: &[ContextComponent]) -> HashSet<String> {
+        components
+            .iter()
+            .flat_map(|c| &c.source_ids)
+            .cloned()
+            .collect()
+    }
+}
+
+#[derive(Debug)]
+pub enum GeneralRagAtError {
+    ParseError(String),
+    InvalidIndexId(String),
+    ReadError,
+}
+
+impl ContextComponent {
+    pub fn new(source_ids: Vec<String>, threshold: f32, max_documents: usize) -> Self {
+        Self {
+            source_ids,
+            threshold,
+            max_documents,
+            fill_remaining: false,
+            is_exclusion: false,
+        }
+    }
+}

--- a/src/ai/ragat.rs
+++ b/src/ai/ragat.rs
@@ -47,15 +47,6 @@ impl std::fmt::Display for ParseError {
 pub struct RAGAtParser;
 
 impl RAGAtParser {
-    /// Parse RAG@ notation string into ContextComponents
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use rag_at::RAGAtParser;
-    ///
-    /// let notation = "[idx1,idx2]@0.7:6; ![idx3,idx4]@0.85:4+";
-    /// let result = RAGAtParser::parse(notation);
     pub fn parse(notation: &str) -> ParseResult {
         match Self::parse_internal(notation) {
             Ok(components) => ParseResult {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod fulltext_search;
 mod index_rebuild;
 mod list_documents;
 mod migrations;
+mod ragat;
 mod replace_doc_on_insert;
 mod replace_index;
 mod shutdown;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,7 +12,6 @@ mod fulltext_search;
 mod index_rebuild;
 mod list_documents;
 mod migrations;
-mod ragat;
 mod replace_doc_on_insert;
 mod replace_index;
 mod shutdown;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1323,6 +1323,7 @@ pub struct Interaction {
     pub min_similarity: Option<f32>,
     pub max_documents: Option<usize>,
     pub ragat_notation: Option<String>,
+    pub search_mode: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1322,6 +1322,7 @@ pub struct Interaction {
     pub llm_config: Option<InteractionLLMConfig>,
     pub min_similarity: Option<f32>,
     pub max_documents: Option<usize>,
+    pub ragat_notation: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1320,6 +1320,8 @@ pub struct Interaction {
     pub related: Option<RelatedRequest>,
     pub messages: Vec<InteractionMessage>,
     pub llm_config: Option<InteractionLLMConfig>,
+    pub min_similarity: Option<f32>,
+    pub max_documents: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/src/web_server/api/collection/answer.rs
+++ b/src/web_server/api/collection/answer.rs
@@ -92,7 +92,7 @@ async fn answer_v1(
     tokio::spawn(async {
         let r = answer.answer(interaction, answer_sender).await;
         if let Err(e) = r {
-            error!(error = ?e, "Failed to run planned answer");
+            error!(error = ?e, "Failed to run answer");
         }
     });
 


### PR DESCRIPTION
This PR adds a new set of practical changes to the Answer API:

- Lowers similarity threshold default to **0.6**.
- Allow custom user-defined similarity via the `min_similarity` property. Values range from 0.1 - 1.0
- Allow custom user-defined maximum number of documents in the context via the `max_documents` property. Values **must be** > 0.
- Allow custom user-defined context prioritarization and distribution via the `ragat_notation` parameter. **RagAt** is a simple string notation used to defined how the context should be composed by the search engine during answering processing. **[ONLY WORKS WITH VECTOR SEARCH]**
- Allow custom user-defined `search_mode`; The values are `fulltext`, `vector`, `hybrid` and `auto`. This implie in the method used to build the context using during the context retrieval.

## FOR NOW: All parameters are set in the root of the payload sent to OramaCore. This may change soon. Be careful while using it.

**Example:**

> If the developer wants the context to prioritize official sources over community data he could use the following RagAt notation: `index1@0.5:3;index2,index4@0.85:2`

In this scenario the `index1` is the official source and has the threshold similarity lower at **0.6** while requiring pottentially noised data (**index2** and **index4**) from community sources to reach a higher similarity.
These solution tend to attenuate the noise added by community data in vector search context.

### Future work:

- Allow exclusion rules to notation (say: add all documents **except** indexFoo)
- Allow complete rule to notation (say: if nothing else matches, **fill with** indexBar)