### PR TITLE
Feat: add suggestions endpoint

### DIFF
--- a/src/ai/answer.rs
+++ b/src/ai/answer.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use futures::{Stream, TryFutureExt};
 use hook_storage::HookReaderError;
+use llm_json::repair_json;
 use orama_js_pool::{ExecOption, JSRunnerError, OutputChannel};
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use thiserror::Error;
@@ -232,68 +233,9 @@ impl Answer {
         sender.send(AnswerEvent::OptimizeingQuery(optimized_query.clone()))?;
 
         let search_results = if let Some(ref notation) = interaction.ragat_notation {
-            let parsed = RAGAtParser::parse(notation);
-
-            let components = self
-                .execute_rag_at_specification(&parsed.components, interaction.clone())
-                .map_err(|_| AnswerError::Generic(anyhow::anyhow!("Error")))
-                .await?;
-
-            let results = self
-                .merge_component_results(components)
-                .map_err(|_| AnswerError::Generic(anyhow::anyhow!("Error")))
-                .await?;
-            results
+            self.get_composed_results(&interaction, notation).await
         } else {
-            let max_documents = Limit(interaction.max_documents.unwrap_or(5));
-            let min_similarity = Similarity(interaction.min_similarity.unwrap_or(0.5));
-
-            let search_mode = match interaction
-                .search_mode
-                .as_ref()
-                .map_or("vector", |s| s.as_str())
-            {
-                "vector" => SearchMode::Vector(VectorMode {
-                    term: interaction.query.clone(),
-                    similarity: min_similarity,
-                }),
-                mode => SearchMode::from_str(mode, interaction.query.clone()),
-            };
-
-            let params = SearchParams {
-                mode: search_mode,
-                limit: max_documents,
-                offset: SearchOffset(0),
-                where_filter: Default::default(),
-                boost: HashMap::new(),
-                facets: HashMap::new(),
-                properties: Properties::Star,
-                indexes: None, // Search all indexes
-                sort_by: None,
-            };
-
-            let hook_storage = self
-                .read_side
-                .get_hook_storage(self.read_api_key, self.collection_id)
-                .await?;
-            let lock = hook_storage.read().await;
-            let params = run_before_retrieval(
-                &lock,
-                params.clone(),
-                log_sender.clone(),
-                ExecOption {
-                    allowed_hosts: Some(vec![]),
-                    timeout: Duration::from_millis(500),
-                },
-            )
-            .await?;
-            drop(lock);
-
-            let result = self
-                .read_side
-                .search(self.read_api_key, self.collection_id, params)
-                .await?;
-            result.hits
+            self.get_search_results(interaction.clone(), log_sender.clone()).await
         };
 
         let search_result_str = serde_json::to_string(&search_results).unwrap();
@@ -372,6 +314,137 @@ impl Answer {
         sender.send(AnswerEvent::AnswerResponse("".to_string()))?;
 
         Ok(())
+    }
+
+    pub async fn suggestions(
+        self,
+        interaction: Interaction,
+        log_sender: Option<Arc<tokio::sync::broadcast::Sender<(OutputChannel, String)>>>,
+    ) -> anyhow::Result<serde_json::Value> {
+        let llm_config: InteractionLLMConfig = self.get_llm_config(&interaction);
+        let llm_service = self.read_side.get_llm_service();
+
+        let optimized_query: String = self.get_optimized_query(&interaction, &llm_config).await; // fallback to the original query if the optimization fails
+        info!("Optimized query: {}", optimized_query);
+
+        let search_results = self.get_search_results(interaction.clone(), log_sender).await;
+        let search_result_str = serde_json::to_string(&search_results).unwrap();
+
+        let mut related_queries_params = llm_service.get_related_questions_params(interaction.related);
+        related_queries_params.push(("context".to_string(), search_result_str));
+        related_queries_params.push(("query".to_string(), interaction.query.clone()));
+
+        let related_questions = llm_service
+            .run_known_prompt(
+                llms::KnownPrompts::GenerateRelatedQueries,
+                related_queries_params,
+                Some(llm_config),
+            )
+            .await?;
+
+        let repaired = match repair_json(&related_questions, &Default::default()) {
+            Ok(json) => json,
+            Err(e) => {
+                anyhow::bail!("JSON repair failed");
+            }
+        };
+
+        let parsed_value = serde_json::from_str(&repaired)?;
+        Ok(parsed_value)
+    }
+    
+    async fn get_optimized_query(&self, interaction: &Interaction, llm_config: &InteractionLLMConfig) -> String {
+        let llm_service = self.read_side.get_llm_service();
+
+        let optimized_query_variables = vec![("input".to_string(), interaction.query.clone())];
+        let optimized_query = llm_service
+            .run_known_prompt(
+                llms::KnownPrompts::OptimizeQuery,
+                optimized_query_variables,
+                Some(llm_config.clone()),
+            )
+            .await
+            .unwrap_or_else(|_| interaction.query.clone()); // fallback to the original query if the optimization fails
+        optimized_query
+    }
+
+    async fn get_composed_results(&self, interaction: &Interaction, notation: &String) -> Vec<SearchResultHit> {
+        let parsed = RAGAtParser::parse(notation);
+
+        let components = match self
+            .execute_rag_at_specification(&parsed.components, interaction.clone())
+            .map_err(|_| AnswerError::Generic(anyhow::anyhow!("Error")))
+            .await {
+                Ok(components) => components,
+                Err(e) => {
+                    warn!("Failed to execute RAGAT specification: {:?}", e);
+                    return vec![];
+                }
+            };
+
+        let results = match self
+            .merge_component_results(components)
+            .map_err(|_| AnswerError::Generic(anyhow::anyhow!("Error")))
+            .await {
+                Ok(results) => results,
+                Err(e) => {
+                    warn!("Failed to merge component results: {:?}", e);
+                    return vec![];
+                }
+            };
+        results
+    }
+
+    async fn get_search_results(&self, interaction: Interaction, log_sender: Option<Arc<tokio::sync::broadcast::Sender<(OutputChannel, String)>>>) -> Vec<SearchResultHit> {
+        let max_documents = Limit(interaction.max_documents.unwrap_or(5));
+        let min_similarity = Similarity(interaction.min_similarity.unwrap_or(0.5));
+
+        let search_mode = match interaction
+            .search_mode
+            .as_ref()
+            .map_or("vector", |s| s.as_str())
+        {
+            "vector" => SearchMode::Vector(VectorMode {
+                term: interaction.query.clone(),
+                similarity: min_similarity,
+            }),
+            mode => SearchMode::from_str(mode, interaction.query.clone()),
+        };
+
+        let params = SearchParams {
+            mode: search_mode,
+            limit: max_documents,
+            offset: SearchOffset(0),
+            where_filter: Default::default(),
+            boost: HashMap::new(),
+            facets: HashMap::new(),
+            properties: Properties::Star,
+            indexes: None, // Search all indexes
+            sort_by: None,
+        };
+
+        let hook_storage = self
+            .read_side
+            .get_hook_storage(self.read_api_key, self.collection_id)
+            .await.unwrap();
+        let lock = hook_storage.read().await;
+        let params = run_before_retrieval(
+            &lock,
+            params.clone(),
+            log_sender.clone(),
+            ExecOption {
+                allowed_hosts: Some(vec![]),
+                timeout: Duration::from_millis(500),
+            },
+        )
+        .await.unwrap();
+        drop(lock);
+
+        let result = self
+            .read_side
+            .search(self.read_api_key, self.collection_id, params)
+            .await.unwrap();
+        result.hits
     }
 
     async fn handle_gpu_overload(&self, interaction: &mut Interaction) {


### PR DESCRIPTION
Enables the generation of suggestions (aka `related queries`) by the using the `/v1/collections/{COLLECTION_ID}/suggestions?api-key={READ_API_KEY}`

The payload is the same used by the `/answer` endpoint.
The response is an objject with a property named `suggestions` and teh value is a vector of strings.

```json
{
    "suggestions": [
        "single sign on solution",
        "web apps and RESTful web services",
        "security features"
    ]
}
``` 