### PR TITLE
feat: rescale cosine similarity on E5-generated text embeddings

### DIFF
--- a/src/ai/answer.rs
+++ b/src/ai/answer.rs
@@ -426,7 +426,8 @@ impl Answer {
         let llm_service = self.read_side.get_llm_service();
 
         let optimized_query_variables = vec![("input".to_string(), interaction.query.clone())];
-        let optimized_query = llm_service
+        // fallback to the original query if the optimization fails
+        llm_service
             .run_known_prompt(
                 llms::KnownPrompts::OptimizeQuery,
                 optimized_query_variables,
@@ -434,8 +435,7 @@ impl Answer {
                 Some(llm_config.clone()),
             )
             .await
-            .unwrap_or_else(|_| interaction.query.clone()); // fallback to the original query if the optimization fails
-        optimized_query
+            .unwrap_or_else(|_| interaction.query.clone())
     }
 
     async fn get_composed_results(
@@ -457,7 +457,7 @@ impl Answer {
             }
         };
 
-        let results = match self
+        match self
             .merge_component_results(components)
             .map_err(|_| AnswerError::Generic(anyhow::anyhow!("Error")))
             .await
@@ -465,10 +465,9 @@ impl Answer {
             Ok(results) => results,
             Err(e) => {
                 warn!("Failed to merge component results: {:?}", e);
-                return vec![];
+                vec![]
             }
-        };
-        results
+        }
     }
 
     async fn get_search_results(

--- a/src/ai/state_machines/answer.rs
+++ b/src/ai/state_machines/answer.rs
@@ -1360,11 +1360,9 @@ impl AnswerStateMachine {
                 .await
                 .map_err(|e| AnswerError::RagAtError(format!("{e:?}")))?;
 
-            let results = self
-                .merge_component_results(components)
+            self.merge_component_results(components)
                 .await
-                .map_err(|e| AnswerError::RagAtError(format!("{e:?}")))?;
-            results
+                .map_err(|e| AnswerError::RagAtError(format!("{e:?}")))?
         } else {
             let max_documents = Limit(interaction.max_documents.unwrap_or(5));
             let min_similarity = Similarity(interaction.min_similarity.unwrap_or(0.5));

--- a/src/ai/training_sets.rs
+++ b/src/ai/training_sets.rs
@@ -284,7 +284,7 @@ impl TrainingSet {
         let collection_stats = self
             .read_side
             .collection_stats(
-                self.read_api_key.clone(),
+                self.read_api_key,
                 self.collection_id,
                 CollectionStatsRequest { with_keys: false },
             )
@@ -323,7 +323,7 @@ impl TrainingSet {
         let random_search_results = self
             .read_side
             .search(
-                self.read_api_key.clone(),
+                self.read_api_key,
                 self.collection_id,
                 search_params,
                 AnalyticSearchEventInvocationType::TrainingDataGen,

--- a/src/collection_manager/sides/read/analytics.rs
+++ b/src/collection_manager/sides/read/analytics.rs
@@ -124,12 +124,11 @@ impl AnalyticsStorage {
 
         let init_file_name: String =
             if BufferedFile::exists_as_file(&data_dir.join("analytics.index")) {
-                let content = BufferedFile::open(data_dir.join("analytics.index"))
+                BufferedFile::open(data_dir.join("analytics.index"))
                     .with_context(|| {
                         format!("Cannot open analytics file at {}", data_dir.display())
                     })?
-                    .read_text_data()?;
-                content
+                    .read_text_data()?
             } else {
                 // Default file name is based on the current timestamp
                 let now = Utc::now().timestamp();

--- a/src/collection_manager/sides/read/index/committed_field/number.rs
+++ b/src/collection_manager/sides/read/index/committed_field/number.rs
@@ -166,11 +166,11 @@ impl BoundedValue for SerializableNumber {
     }
 }
 
-pub fn get_iter<'s, K: Ord + Eq>(
-    vec: &'s [(K, HashSet<DocumentId>)],
+pub fn get_iter<K: Ord + Eq>(
+    vec: &[(K, HashSet<DocumentId>)],
     min: (bool, K),
     max: (bool, K),
-) -> impl Iterator<Item = DocumentId> + 's {
+) -> impl Iterator<Item = DocumentId> + '_ {
     let min_index = match vec.binary_search_by_key(&&min.1, |(num, _)| num) {
         Ok(index) => {
             // vec[index] is == min.1

--- a/src/collection_manager/sides/read/index/committed_field/vector.rs
+++ b/src/collection_manager/sides/read/index/committed_field/vector.rs
@@ -135,6 +135,15 @@ impl CommittedVectorField {
         }
     }
 
+    fn is_e5_model(&self) -> bool {
+        matches!(
+            self.model,
+            OramaModel::MultilingualE5Small
+                | OramaModel::MultilingualE5Base
+                | OramaModel::MultilingualE5Large
+        )
+    }
+
     pub fn search(
         &self,
         target: &[f32],
@@ -160,13 +169,19 @@ impl CommittedVectorField {
             limit * 2
         };
         let data = self.inner.search(target.to_vec(), limit * 2);
+        let is_e5_model = self.is_e5_model();
 
-        for (doc_id, score) in data {
+        for (doc_id, mut score) in data {
             if filtered_doc_ids.is_some_and(|ids| !ids.contains(&doc_id)) {
                 continue;
             }
             if uncommitted_deleted_documents.contains(&doc_id) {
                 continue;
+            }
+
+            // Rescale E5 model scores from [0.7, 1.0] to [0.0, 1.0]
+            if is_e5_model {
+                score = rescale_e5_similarity_score(score);
             }
 
             if score >= similarity {
@@ -191,6 +206,20 @@ pub struct VectorFieldInfo {
     pub field_path: Box<[String]>,
     pub data_dir: PathBuf,
     pub model: OramaModelSerializable,
+}
+
+/// Rescales E5 embedding model cosine similarity scores from their typical range [0.7, 1.0] to [0.0, 1.0].
+/// E5 models produce similarity scores that rarely go below 0.7, making the effective range much narrower.
+/// This rescaling helps normalize the scores to use the full [0.0, 1.0] range for better search ranking.
+fn rescale_e5_similarity_score(score: f32) -> f32 {
+    const E5_MIN_SCORE: f32 = 0.7;
+    const E5_MAX_SCORE: f32 = 1.0;
+
+    // Clamp the score to the expected E5 range to handle edge cases
+    let clamped_score = score.clamp(E5_MIN_SCORE, E5_MAX_SCORE);
+
+    // Rescale from [0.7, 1.0] to [0.0, 1.0]
+    (clamped_score - E5_MIN_SCORE) / (E5_MAX_SCORE - E5_MIN_SCORE)
 }
 
 #[derive(Serialize, Debug)]

--- a/src/collection_manager/sides/read/index/uncommitted_field/geopoint.rs
+++ b/src/collection_manager/sides/read/index/uncommitted_field/geopoint.rs
@@ -49,7 +49,7 @@ impl UncommittedGeoPointFilterField {
         self.inner.clone()
     }
 
-    pub fn iter<'s>(&'s self) -> impl Iterator<Item = &'s Point<f32, DocumentId>> + 's {
+    pub fn iter(&self) -> impl Iterator<Item = &Point<f32, DocumentId>> + '_ {
         self.inner.iter()
     }
 

--- a/src/collection_manager/sides/read/mod.rs
+++ b/src/collection_manager/sides/read/mod.rs
@@ -992,7 +992,7 @@ pub struct HookReaderLock<'guard> {
     collection: CollectionReadLock<'guard>,
 }
 
-impl<'guard> Deref for HookReaderLock<'guard> {
+impl Deref for HookReaderLock<'_> {
     type Target = RwLock<HookReader>;
 
     fn deref(&self) -> &Self::Target {

--- a/src/collection_manager/sides/write/mod.rs
+++ b/src/collection_manager/sides/write/mod.rs
@@ -1204,7 +1204,7 @@ impl WriteSide {
         self.check_write_api_key(collection_id, write_api_key)
             .await?;
 
-        return Ok(self.training_sets.clone());
+        Ok(self.training_sets.clone())
     }
 
     pub fn get_jwt_manager(&self) -> JwtManager {
@@ -1317,7 +1317,7 @@ fn default_insert_batch_commit_size() -> u64 {
 pub struct HookWriterLock<'guard> {
     collection: CollectionReadLock<'guard>,
 }
-impl<'guard> Deref for HookWriterLock<'guard> {
+impl Deref for HookWriterLock<'_> {
     type Target = HookWriter;
 
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
This pull request introduces improvements and refactoring across several modules, with a focus on vector search scoring for E5 embedding models, code simplification, and minor API optimizations. The most significant update is the normalization of E5 model similarity scores to improve search ranking. Several lifetime annotations and redundant code patterns are also streamlined for clarity and efficiency.

### Vector Search and E5 Model Scoring Improvements

* Added E5 model detection methods (`is_e5_model`) to both `CommittedVectorField` and `UncommittedVectorField`, and implemented a normalization function to rescale E5 cosine similarity scores from `[0.7, 1.0]` to `[0.0, 1.0]` for more effective search ranking. This normalization is now applied during vector searches in both committed and uncommitted fields. [[1]](diffhunk://#diff-f0a4545487e52c817fe1e026490ee0fc7f4d1e6e5767e037ba51d243bf1d636eR138-R146) [[2]](diffhunk://#diff-f0a4545487e52c817fe1e026490ee0fc7f4d1e6e5767e037ba51d243bf1d636eR172-R186) [[3]](diffhunk://#diff-f0a4545487e52c817fe1e026490ee0fc7f4d1e6e5767e037ba51d243bf1d636eR211-R224) [[4]](diffhunk://#diff-142e71ffa1ef065fb3c23ed22d37e41f19473cd1d6a19436a8706dff5f5f3c02R50-R58) [[5]](diffhunk://#diff-142e71ffa1ef065fb3c23ed22d37e41f19473cd1d6a19436a8706dff5f5f3c02L69-R84) [[6]](diffhunk://#diff-142e71ffa1ef065fb3c23ed22d37e41f19473cd1d6a19436a8706dff5f5f3c02R161-R174)

### Code Simplification and Refactoring

* Simplified error handling and result merging logic in the `Answer` and `AnswerStateMachine` implementations, removing unnecessary intermediate variables and clarifying fallback behavior. [[1]](diffhunk://#diff-11e072967beb59232bd503493c3b6308756dba02f34ab590c23e54a45f911927L429-R438) [[2]](diffhunk://#diff-11e072967beb59232bd503493c3b6308756dba02f34ab590c23e54a45f911927L460-L471) [[3]](diffhunk://#diff-b2220dba371bd8f0a4ee51e1cdd0745b89e29fde97561bcca88d23913f2f29a7L1363-R1365)
* Updated lifetime annotations for iterator and deref implementations to use elided lifetimes (`'_`) for improved readability and idiomatic Rust usage. [[1]](diffhunk://#diff-ae8c0f45e75485869d07b8453bb5fa3aeb74652f5e6936404c49ece9bba53398L169-R173) [[2]](diffhunk://#diff-7c530257309b76b7c83e6cb2f05f61f17ea0b7bf4028c1f436a4e7aaf380dda9L52-R52) [[3]](diffhunk://#diff-3c26b365ec24b9a240dd3712e475bb46c6231ae4cf1c127813e6eb2c2b40c33fL995-R995) [[4]](diffhunk://#diff-6246ca4a6dcb84f1aeaa393153531adc7279f64c5be15389123e7d37382532cdL1320-R1320)

### API Usage and Minor Optimizations

* Removed unnecessary `.clone()` calls for API key parameters in `TrainingSet` methods, passing ownership directly for efficiency. [[1]](diffhunk://#diff-cb3f93508314d34ab9f59cfbd75d9b87998c8ab65692d8e40c3ae0dec0122a1eL287-R287) [[2]](diffhunk://#diff-cb3f93508314d34ab9f59cfbd75d9b87998c8ab65692d8e40c3ae0dec0122a1eL326-R326)
* Minor code cleanup in analytics file initialization and write-side training set retrieval, removing redundant variable assignments and returns. [[1]](diffhunk://#diff-4d0370d9b6c21c51cfd7063898c1df021d081b928af829785755439c252d8a13L127-R131) [[2]](diffhunk://#diff-6246ca4a6dcb84f1aeaa393153531adc7279f64c5be15389123e7d37382532cdL1207-R1207)