### PR TITLE
Fix: re-add SearchResults event to AnswerStateMachine (O-3032)

### DIFF
--- a/src/ai/state_machines/answer.rs
+++ b/src/ai/state_machines/answer.rs
@@ -600,6 +600,11 @@ impl AnswerStateMachine {
                         )
                         .await?;
 
+                    self.send_event(AnswerEvent::SearchResults {
+                        results: search_results.clone(),
+                    })
+                    .await;
+
                     self.send_event(AnswerEvent::StateChanged {
                         state: "execute_search".to_string(),
                         message: "Executing search".to_string(),


### PR DESCRIPTION
This PR should enable sse-parser and oramaclient-js (+UI Components) to be able to render sources properly.