### PR TITLE
ci: migrate self-hosted runners from GCP to AWS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: [self-hosted, gpu, cuda]
+    runs-on: [self-hosted, aws, linux, x86_64]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   build-and-patch-release:
     name: Build and Upload Release Assets
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, aws, linux, x86_64]
 
     steps:
       - name: Checkout code
@@ -94,7 +94,7 @@ jobs:
   build-docker-OramaCore-x86_64:
     needs: [build-and-patch-release]
     name: Build and Upload Docker Images
-    runs-on: [self-hosted, X64]
+    runs-on: [self-hosted, aws, linux, x86_64]
 
     steps:
       - name: Checkout code
@@ -149,7 +149,7 @@ jobs:
   build-docker-OramaCore-arm64:
     needs: [build-and-patch-release]
     name: Build and Upload Docker Images
-    runs-on: [self-hosted, arm64]
+    runs-on: [self-hosted, aws, linux, arm64]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Switches all self-hosted runner labels in `ci.yml` and `release-build.yml` from the GCP runner pool to the new AWS self-hosted runner pool managed in [`oramasearch/oramacore-aws`](https://github.com/oramasearch/oramacore-aws). **Labels-only change** — no other workflow modifications.

| Workflow / Job | Before | After |
|---|---|---|
| `ci.yml` → `build` | `[self-hosted, gpu, cuda]` | `[self-hosted, aws, linux, x86_64]` |
| `release-build.yml` → `build-and-patch-release` | `[self-hosted, X64]` | `[self-hosted, aws, linux, x86_64]` |
| `release-build.yml` → `build-docker-OramaCore-x86_64` | `[self-hosted, X64]` | `[self-hosted, aws, linux, x86_64]` |
| `release-build.yml` → `build-docker-OramaCore-arm64` | `[self-hosted, arm64]` | `[self-hosted, aws, linux, arm64]` |

## Why

- GCP self-hosted runner pool is being decommissioned.
- New AWS runner pool is pre-provisioned with every dependency these workflows install at job time: Python 3.11 (deadsnakes), Rust 1.91.1 (pinned + clippy + rustfmt), `protoc`, `librocksdb-dev`, `libssl-dev`, `pkg-config`, compression libs, `build-essential`, Docker + buildx.
- All existing `sudo apt-get install ...` / toolchain setup steps remain unchanged and run as no-ops on warm runners (~5s overhead).
- GPU/CUDA is intentionally dropped. End-to-end CPU validation was performed via a dedicated smoke test: every module in `requirements.txt` (torch, onnxruntime, fastembed, bitsandbytes, accelerate, einops, etc.) imports cleanly on CPU-only AWS hosts. Expect longer CI wall time on ONNX/fastembed-heavy tests.

## Validation

Smoke test run in `oramacore-aws`: [run 24288118981](https://github.com/oramasearch/oramacore-aws/actions/runs/24288118981) — synthetic crate using the same heavy deps (`pyo3 0.27`, `reqwest`, `tokio`, `serde`) built with Rust 1.91.1 targeting `x86_64-unknown-linux-gnu` and `aarch64-unknown-linux-gnu`. Host-build jobs passed end-to-end on both architectures. Python venv + full `requirements.txt` install + import probe confirmed CPU compatibility.

## Known pre-existing issue (NOT caused by this PR)

`release-build.yml`'s Docker jobs currently fail on **both GCP and AWS** because `docker/Dockerfile-oramacore-{x86,arm64}` pins `FROM rust:1.85-slim-bookworm` while transitive dep `wit-bindgen-rust v0.51.0` now requires Rust ≥ 1.87. This is independent of the runner migration and will be addressed in a separate PR bumping the base image to `rust:1.91-slim-bookworm`.

## Test plan

- [ ] This PR's own CI run (`ci.yml`) executes on AWS runners and passes
- [ ] Monitor runner auto-start via webhook: https://9xfk6cfarf.execute-api.us-east-2.amazonaws.com/both
- [ ] Next 2-3 PRs on `develop` remain stable on AWS runners
- [ ] Decommission GCP runners once stable