### PR TITLE
ci: bump Docker base image rust 1.85 -> 1.91

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -3,6 +3,9 @@ name: Build and Release
 on:
   release:
     types: [created]
+  # TEMP: remove before merging — added to validate Dockerfile rust:1.91 bump
+  # against the AWS self-hosted runners without cutting a real release.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -86,6 +86,10 @@ jobs:
         run: cp ./target/release/oramacore ./target/release/oramacore-writer
 
       - name: Upload Binaries to Release
+        # TEMP: skip upload on workflow_dispatch (no release object to attach
+        # to). Remove this `if` together with the workflow_dispatch trigger
+        # before merging.
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v1
         with:
           files: |

--- a/docker/Dockerfile-oramacore-arm64
+++ b/docker/Dockerfile-oramacore-arm64
@@ -11,7 +11,7 @@ RUN python3.11 -m venv .venv && \
     .venv/bin/pip install -r requirements-cpu.txt
 
 # Stage 2: Build Rust application with PyO3
-FROM rust:1.85-slim-bookworm AS rust-builder
+FROM rust:1.91-slim-bookworm AS rust-builder
 
 # Install build dependencies including Python 3.11 dev headers for PyO3
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile-oramacore-x86
+++ b/docker/Dockerfile-oramacore-x86
@@ -10,7 +10,7 @@ RUN python3.11 -m venv .venv && \
     .venv/bin/pip install -r requirements.txt
 
 # Stage 2: Build Rust application with PyO3
-FROM rust:1.85-slim-bookworm AS rust-builder
+FROM rust:1.91-slim-bookworm AS rust-builder
 
 # Install build dependencies including Python 3.11 dev headers for PyO3
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## What

Bumps Docker base image from `rust:1.85-slim-bookworm` → `rust:1.91-slim-bookworm` in both `docker/Dockerfile-oramacore-x86` and `docker/Dockerfile-oramacore-arm64`.

## Why

`release-build.yml` Docker jobs currently fail with:

```
error: rustc 1.85.1 is not supported by the following packages:
  Adding wit-bindgen-rust v0.51.0 (requires Rust 1.87.0)
```

Bumping to `1.91` matches the host toolchain already used by the workflow (`actions-rust-lang/setup-rust-toolchain@v1` → `toolchain: 1.91.1`).

**This bug has been broken in production for ~6 weeks** — the last two release runs both failed with it:

| Release | Run | Date |
|---|---|---|
| `v1.2.38` | [24076802108](https://github.com/oramasearch/oramacore/actions/runs/24076802108) | 2026-04-07 |
| `v1.2.37` | [23152091139](https://github.com/oramasearch/oramacore/actions/runs/23152091139) | 2026-03-16 |

It is unrelated to the recent AWS runner migration (#332) — that migration only surfaced it.

## Validation

Dispatched manually against this branch:
- Run 24290855006 — in progress: https://github.com/oramasearch/oramacore/actions/runs/24290855006