### PR TITLE
fix: correct npm bugs metadata URL

### DIFF
--- a/client/js/sse-parser/dnt.ts
+++ b/client/js/sse-parser/dnt.ts
@@ -30,7 +30,7 @@ await build({
       url: 'git+https://github.com/oramasearch/oramacore.git',
     },
     bugs: {
-      url: 'https://github.com/oramasearch/oramacore/repo/issues',
+      url: 'https://github.com/oramasearch/oramacore/issues',
     },
   },
   testPattern: '**/*_test.{ts,js}',


### PR DESCRIPTION
## Summary
- correct the generated npm bugs.url for @orama/core
- point package consumers to the repository issue tracker instead of the non-existent /repo/issues path

## Verification
- npm view @orama/core@1.2.19 bugs --json shows the current published URL contains /repo/issues
- checked client/js/sse-parser/dnt.ts now emits https://github.com/oramasearch/oramacore/issues